### PR TITLE
Fix shared db path across workspace packages

### DIFF
--- a/packages/wallet-core/src/db/connection.ts
+++ b/packages/wallet-core/src/db/connection.ts
@@ -1,11 +1,19 @@
+import { resolve } from "path";
+import { fileURLToPath } from "url";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import * as schema from "./schema.js";
 
 let _db: ReturnType<typeof createDb> | null = null;
 
+function defaultDbPath() {
+  // Always resolve relative to the monorepo root so all packages share one db
+  const walletCoreSrc = fileURLToPath(new URL(".", import.meta.url));
+  return resolve(walletCoreSrc, "../../../..", "gentwallet.db");
+}
+
 function createDb(dbPath?: string) {
-  const sqlite = new Database(dbPath ?? "gentwallet.db");
+  const sqlite = new Database(dbPath ?? process.env.DB_PATH ?? defaultDbPath());
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("foreign_keys = ON");
   return drizzle(sqlite, { schema });


### PR DESCRIPTION
## Summary

- All workspace packages (auth-service, demo-seed, mcp-server) now resolve `gentwallet.db` to the monorepo root instead of their own package directory
- Uses `import.meta.url` to compute an absolute path from wallet-core's location
- Supports `DB_PATH` env var override

This fixes the bug where `npm run seed` wrote data to `packages/demo-seed/gentwallet.db` while `npm run dev:auth` read from `packages/auth-service/gentwallet.db`, resulting in an empty dashboard.

## Test plan

- [x] 26 wallet-core tests pass (tests use in-memory db, unaffected)
- [ ] `rm gentwallet.db && npm run db:migrate && npm run seed` creates single db at root
- [ ] `npm run dev:auth` → `curl localhost:3001/api/balance/demo-wallet` returns seeded data
- [ ] Dashboard shows live balance, transactions, rules, notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)